### PR TITLE
fixed benchmark "acquire ip" - use updated prefix for next round

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ip's from prefixes.
 
 ## Prefix
 
-A prefix is a network with ip and mask, typicaly in the form of *192.168.0.0/24*. To be able to manage IPs you have to create a prefix first.
+A prefix is a network with ip and mask, typically in the form of *192.168.0.0/24*. To be able to manage IPs you have to create a prefix first.
 
 example usage:
 
@@ -43,7 +43,7 @@ func main() {
     }
     fmt.Printf("got IP: %s", ip.IP)
 
-    err = ipam.ReleaseIP(ip)
+    prefix, err = ipam.ReleaseIP(ip)
     if err != nil {
         panic(err)
     }
@@ -56,16 +56,16 @@ func main() {
 ```bash
 BenchmarkNewPrefixMemory-4                500000              4629 ns/op
 BenchmarkNewPrefixPostgres-4                 200           7425393 ns/op
-BenchmarkAquireIPMemory-4                2000000              1110 ns/op
-BenchmarkAquireIPPostgres-4                  100          10508799 ns/op
-BenchmarkAquireChildPrefix1-4             300000              3693 ns/op
-BenchmarkAquireChildPrefix2-4             300000              3727 ns/op
-BenchmarkAquireChildPrefix3-4             300000              4036 ns/op
-BenchmarkAquireChildPrefix4-4             300000              4372 ns/op
-BenchmarkAquireChildPrefix5-4             200000              5448 ns/op
-BenchmarkAquireChildPrefix6-4             300000              3729 ns/op
-BenchmarkAquireChildPrefix7-4             300000              3766 ns/op
-BenchmarkAquireChildPrefix8-4             500000              3986 ns/op
-BenchmarkAquireChildPrefix9-4             300000              3934 ns/op
-BenchmarkAquireChildPrefix10-4            300000              3858 ns/op
+BenchmarkAcquireIPMemory-4                2000000              1110 ns/op
+BenchmarkAcquireIPPostgres-4                  100          10508799 ns/op
+BenchmarkAcquireChildPrefix1-4             300000              3693 ns/op
+BenchmarkAcquireChildPrefix2-4             300000              3727 ns/op
+BenchmarkAcquireChildPrefix3-4             300000              4036 ns/op
+BenchmarkAcquireChildPrefix4-4             300000              4372 ns/op
+BenchmarkAcquireChildPrefix5-4             200000              5448 ns/op
+BenchmarkAcquireChildPrefix6-4             300000              3729 ns/op
+BenchmarkAcquireChildPrefix7-4             300000              3766 ns/op
+BenchmarkAcquireChildPrefix8-4             500000              3986 ns/op
+BenchmarkAcquireChildPrefix9-4             300000              3934 ns/op
+BenchmarkAcquireChildPrefix10-4            300000              3858 ns/op
 ```

--- a/ipam_test.go
+++ b/ipam_test.go
@@ -47,12 +47,12 @@ func ExampleIpamer_NewPrefix() {
 	// 192.168.0.2
 	// 192.168.0.0/24
 
-	err = ipamer.ReleaseIP(ip2)
+	_, err = ipamer.ReleaseIP(ip2)
 	if err != nil {
 		panic(err)
 	}
 
-	err = ipamer.ReleaseIP(ip1)
+	_, err = ipamer.ReleaseIP(ip1)
 	if err != nil {
 		panic(err)
 	}

--- a/prefix.go
+++ b/prefix.go
@@ -120,7 +120,7 @@ func (i *Ipamer) AcquireChildPrefix(prefix *Prefix, length int) (*Prefix, error)
 
 	prefix.availableChildPrefixes[child.Cidr] = false
 
-	i.storage.UpdatePrefix(prefix)
+	_, err = i.storage.UpdatePrefix(prefix)
 	child, err = i.NewPrefix(child.Cidr)
 	child.ParentCidr = prefix.Cidr
 	if err != nil {
@@ -198,10 +198,10 @@ func (i *Ipamer) AcquireIP(prefix *Prefix) (*IP, error) {
 	return nil, fmt.Errorf("no more ips in prefix: %s left, length of prefix.ips: %d", prefix.Cidr, len(prefix.ips))
 }
 
-// ReleaseIP will release the given IP for later usage.
-func (i *Ipamer) ReleaseIP(ip *IP) error {
+// ReleaseIP will release the given IP for later usage and returns the updated Prefix.
+func (i *Ipamer) ReleaseIP(ip *IP) (*Prefix, error) {
 	prefix := i.PrefixFrom(ip.ParentPrefix)
-	return i.ReleaseIPFromPrefix(prefix, ip.IP.String())
+	return prefix, i.ReleaseIPFromPrefix(prefix, ip.IP.String())
 }
 
 // ReleaseIPFromPrefix will release the given IP for later usage.

--- a/prefix_benchmark_test.go
+++ b/prefix_benchmark_test.go
@@ -30,7 +30,7 @@ func BenchmarkNewPrefixPostgres(b *testing.B) {
 	benchmarkNewPrefix(ipam, b)
 }
 
-func benchmarkAquireIP(ipam *Ipamer, cidr string, b *testing.B) {
+func benchmarkAcquireIP(ipam *Ipamer, cidr string, b *testing.B) {
 	p, err := ipam.NewPrefix(cidr)
 	if err != nil {
 		panic(err)
@@ -43,28 +43,28 @@ func benchmarkAquireIP(ipam *Ipamer, cidr string, b *testing.B) {
 		if ip == nil {
 			panic("IP nil")
 		}
-		err = ipam.ReleaseIP(ip)
+		p, err = ipam.ReleaseIP(ip)
 		if err != nil {
 			panic(err)
 		}
 	}
 	_, err = ipam.DeletePrefix(cidr)
 	if err != nil {
-		b.Logf("error deleting prefix:%v", err)
+		b.Fatalf("error deleting prefix:%v", err)
 	}
 }
 
-func BenchmarkAquireIPMemory(b *testing.B) {
+func BenchmarkAcquireIPMemory(b *testing.B) {
 	ipam := New()
-	benchmarkAquireIP(ipam, "11.0.0.0/24", b)
+	benchmarkAcquireIP(ipam, "11.0.0.0/24", b)
 }
-func BenchmarkAquireIPPostgres(b *testing.B) {
+func BenchmarkAcquireIPPostgres(b *testing.B) {
 	storage, _ := NewPostgresStorage("localhost", "5433", "postgres", "password", "postgres", "disable")
 	ipam := NewWithStorage(storage)
-	benchmarkAquireIP(ipam, "10.0.0.0/16", b)
+	benchmarkAcquireIP(ipam, "10.0.0.0/16", b)
 }
 
-func benchmarkAquireChildPrefix(parentLength, childLength int, b *testing.B) {
+func benchmarkAcquireChildPrefix(parentLength, childLength int, b *testing.B) {
 	ipam := New()
 	p, err := ipam.NewPrefix(fmt.Sprintf("192.168.0.0/%d", parentLength))
 	if err != nil {
@@ -82,19 +82,19 @@ func benchmarkAquireChildPrefix(parentLength, childLength int, b *testing.B) {
 	}
 	_, err = ipam.DeletePrefix(p.Cidr)
 	if err != nil {
-		b.Logf("error deleting prefix:%v", err)
+		b.Fatalf("error deleting prefix:%v", err)
 	}
 }
-func BenchmarkAquireChildPrefix1(b *testing.B)  { benchmarkAquireChildPrefix(8, 14, b) }
-func BenchmarkAquireChildPrefix2(b *testing.B)  { benchmarkAquireChildPrefix(8, 16, b) }
-func BenchmarkAquireChildPrefix3(b *testing.B)  { benchmarkAquireChildPrefix(8, 20, b) }
-func BenchmarkAquireChildPrefix4(b *testing.B)  { benchmarkAquireChildPrefix(8, 22, b) }
-func BenchmarkAquireChildPrefix5(b *testing.B)  { benchmarkAquireChildPrefix(8, 24, b) }
-func BenchmarkAquireChildPrefix6(b *testing.B)  { benchmarkAquireChildPrefix(16, 18, b) }
-func BenchmarkAquireChildPrefix7(b *testing.B)  { benchmarkAquireChildPrefix(16, 20, b) }
-func BenchmarkAquireChildPrefix8(b *testing.B)  { benchmarkAquireChildPrefix(16, 22, b) }
-func BenchmarkAquireChildPrefix9(b *testing.B)  { benchmarkAquireChildPrefix(16, 24, b) }
-func BenchmarkAquireChildPrefix10(b *testing.B) { benchmarkAquireChildPrefix(16, 26, b) }
+func BenchmarkAcquireChildPrefix1(b *testing.B)  { benchmarkAcquireChildPrefix(8, 14, b) }
+func BenchmarkAcquireChildPrefix2(b *testing.B)  { benchmarkAcquireChildPrefix(8, 16, b) }
+func BenchmarkAcquireChildPrefix3(b *testing.B)  { benchmarkAcquireChildPrefix(8, 20, b) }
+func BenchmarkAcquireChildPrefix4(b *testing.B)  { benchmarkAcquireChildPrefix(8, 22, b) }
+func BenchmarkAcquireChildPrefix5(b *testing.B)  { benchmarkAcquireChildPrefix(8, 24, b) }
+func BenchmarkAcquireChildPrefix6(b *testing.B)  { benchmarkAcquireChildPrefix(16, 18, b) }
+func BenchmarkAcquireChildPrefix7(b *testing.B)  { benchmarkAcquireChildPrefix(16, 20, b) }
+func BenchmarkAcquireChildPrefix8(b *testing.B)  { benchmarkAcquireChildPrefix(16, 22, b) }
+func BenchmarkAcquireChildPrefix9(b *testing.B)  { benchmarkAcquireChildPrefix(16, 24, b) }
+func BenchmarkAcquireChildPrefix10(b *testing.B) { benchmarkAcquireChildPrefix(16, 26, b) }
 
 func BenchmarkPrefixOverlapping(b *testing.B) {
 	ipam := New()


### PR DESCRIPTION
api-change: ipamer.ReleaseIP now returns the updated prefix