### PR TITLE
cleanup

### DIFF
--- a/memory.go
+++ b/memory.go
@@ -2,22 +2,28 @@ package ipam
 
 import (
 	"fmt"
+	"sync"
 )
 
 type memory struct {
 	prefixes map[string]*Prefix
+	lock     sync.RWMutex
 }
 
 // NewMemory create a memory storage for ipam
 func NewMemory() *memory {
 	prefixes := make(map[string]*Prefix)
+	lock := sync.RWMutex{}
 	return &memory{
 		prefixes: prefixes,
+		lock:     lock,
 	}
-
 }
 
 func (m *memory) CreatePrefix(prefix *Prefix) (*Prefix, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
 	_, ok := m.prefixes[prefix.Cidr]
 	if ok {
 		return nil, fmt.Errorf("prefix already created:%v", prefix)
@@ -26,9 +32,15 @@ func (m *memory) CreatePrefix(prefix *Prefix) (*Prefix, error) {
 	return prefix, nil
 }
 func (m *memory) ReadPrefix(prefix string) (*Prefix, error) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
 	return m.prefixes[prefix], nil
 }
 func (m *memory) ReadAllPrefixes() ([]*Prefix, error) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
 	ps := make([]*Prefix, 0, len(m.prefixes))
 	for _, v := range m.prefixes {
 		ps = append(ps, v)
@@ -36,6 +48,9 @@ func (m *memory) ReadAllPrefixes() ([]*Prefix, error) {
 	return ps, nil
 }
 func (m *memory) UpdatePrefix(prefix *Prefix) (*Prefix, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
 	if prefix.Cidr == "" {
 		return nil, fmt.Errorf("prefix not present:%v", prefix)
 	}
@@ -47,6 +62,9 @@ func (m *memory) UpdatePrefix(prefix *Prefix) (*Prefix, error) {
 	return prefix, nil
 }
 func (m *memory) DeletePrefix(prefix *Prefix) (*Prefix, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
 	delete(m.prefixes, prefix.Cidr)
 	return prefix, nil
 }

--- a/memory.go
+++ b/memory.go
@@ -29,7 +29,7 @@ func (m *memory) CreatePrefix(prefix Prefix) (Prefix, error) {
 	if ok {
 		return Prefix{}, fmt.Errorf("prefix already created:%v", prefix)
 	}
-	m.prefixes[prefix.Cidr] = prefix
+	m.prefixes[prefix.Cidr] = *prefix.DeepCopy()
 	return prefix, nil
 }
 func (m *memory) ReadPrefix(prefix string) (Prefix, error) {
@@ -40,7 +40,7 @@ func (m *memory) ReadPrefix(prefix string) (Prefix, error) {
 	if !ok {
 		return Prefix{}, errors.Errorf("Prefix %s not found", prefix)
 	}
-	return result, nil
+	return *result.DeepCopy(), nil
 }
 func (m *memory) ReadAllPrefixes() ([]Prefix, error) {
 	m.lock.RLock()
@@ -48,7 +48,7 @@ func (m *memory) ReadAllPrefixes() ([]Prefix, error) {
 
 	ps := make([]Prefix, 0, len(m.prefixes))
 	for _, v := range m.prefixes {
-		ps = append(ps, v)
+		ps = append(ps, *v.DeepCopy())
 	}
 	return ps, nil
 }
@@ -63,7 +63,7 @@ func (m *memory) UpdatePrefix(prefix Prefix) (Prefix, error) {
 	if !ok {
 		return Prefix{}, fmt.Errorf("prefix not found:%s", prefix.Cidr)
 	}
-	m.prefixes[prefix.Cidr] = prefix
+	m.prefixes[prefix.Cidr] = *prefix.DeepCopy()
 	return prefix, nil
 }
 func (m *memory) DeletePrefix(prefix Prefix) (Prefix, error) {
@@ -71,5 +71,5 @@ func (m *memory) DeletePrefix(prefix Prefix) (Prefix, error) {
 	defer m.lock.Unlock()
 
 	delete(m.prefixes, prefix.Cidr)
-	return prefix, nil
+	return *prefix.DeepCopy(), nil
 }

--- a/memory.go
+++ b/memory.go
@@ -2,17 +2,18 @@ package ipam
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"sync"
 )
 
 type memory struct {
-	prefixes map[string]*Prefix
+	prefixes map[string]Prefix
 	lock     sync.RWMutex
 }
 
 // NewMemory create a memory storage for ipam
 func NewMemory() *memory {
-	prefixes := make(map[string]*Prefix)
+	prefixes := make(map[string]Prefix)
 	lock := sync.RWMutex{}
 	return &memory{
 		prefixes: prefixes,
@@ -20,48 +21,52 @@ func NewMemory() *memory {
 	}
 }
 
-func (m *memory) CreatePrefix(prefix *Prefix) (*Prefix, error) {
+func (m *memory) CreatePrefix(prefix Prefix) (Prefix, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
 	_, ok := m.prefixes[prefix.Cidr]
 	if ok {
-		return nil, fmt.Errorf("prefix already created:%v", prefix)
+		return Prefix{}, fmt.Errorf("prefix already created:%v", prefix)
 	}
 	m.prefixes[prefix.Cidr] = prefix
 	return prefix, nil
 }
-func (m *memory) ReadPrefix(prefix string) (*Prefix, error) {
+func (m *memory) ReadPrefix(prefix string) (Prefix, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
-	return m.prefixes[prefix], nil
+	result, ok := m.prefixes[prefix]
+	if !ok {
+		return Prefix{}, errors.Errorf("Prefix %s not found", prefix)
+	}
+	return result, nil
 }
-func (m *memory) ReadAllPrefixes() ([]*Prefix, error) {
+func (m *memory) ReadAllPrefixes() ([]Prefix, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
-	ps := make([]*Prefix, 0, len(m.prefixes))
+	ps := make([]Prefix, 0, len(m.prefixes))
 	for _, v := range m.prefixes {
 		ps = append(ps, v)
 	}
 	return ps, nil
 }
-func (m *memory) UpdatePrefix(prefix *Prefix) (*Prefix, error) {
+func (m *memory) UpdatePrefix(prefix Prefix) (Prefix, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
 	if prefix.Cidr == "" {
-		return nil, fmt.Errorf("prefix not present:%v", prefix)
+		return Prefix{}, fmt.Errorf("prefix not present:%v", prefix)
 	}
 	_, ok := m.prefixes[prefix.Cidr]
 	if !ok {
-		return nil, fmt.Errorf("prefix not found:%v", prefix)
+		return Prefix{}, fmt.Errorf("prefix not found:%s", prefix.Cidr)
 	}
 	m.prefixes[prefix.Cidr] = prefix
 	return prefix, nil
 }
-func (m *memory) DeletePrefix(prefix *Prefix) (*Prefix, error) {
+func (m *memory) DeletePrefix(prefix Prefix) (Prefix, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 

--- a/memory_test.go
+++ b/memory_test.go
@@ -7,19 +7,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_ReadPrefix(t *testing.T) {
+	m := NewMemory()
+
+	// Prefix
+	p, err := m.ReadPrefix("12.0.0.0/8")
+	require.NotNil(t, err)
+	require.Equal(t, "Prefix 12.0.0.0/8 not found", err.Error())
+	require.Empty(t, p)
+
+	prefix := Prefix{Cidr: "12.0.0.0/16"}
+	p, err = m.CreatePrefix(prefix)
+	require.Nil(t, err)
+	require.NotNil(t, p)
+
+	p, err = m.ReadPrefix("12.0.0.0/16")
+	require.Nil(t, err)
+	require.NotNil(t, p)
+	require.Equal(t, "12.0.0.0/16", p.Cidr)
+}
+
 func Test_UpdatePrefix(t *testing.T) {
 	m := NewMemory()
 
-	prefix := &Prefix{}
+	prefix := Prefix{}
 	p, err := m.UpdatePrefix(prefix)
 	require.NotNil(t, err)
-	require.Nil(t, p)
-	require.Equal(t, "prefix not present:", err.Error())
+	require.Empty(t, p)
+	require.Equal(t, "prefix not present:{  map[] 0 map[] 0}", err.Error())
 
 	prefix.Cidr = "1.2.3.4/24"
 	p, err = m.UpdatePrefix(prefix)
 	require.NotNil(t, err)
-	require.Nil(t, p)
+	require.Empty(t, p)
 	require.Equal(t, "prefix not found:1.2.3.4/24", err.Error())
 }
 
@@ -30,7 +50,7 @@ func Test_UpdatePrefix_Concurrent(t *testing.T) {
 	for i := 0; i < 50000; i++ {
 
 		go func(run int) {
-			prefix := &Prefix{}
+			prefix := Prefix{}
 			cidr := calcPrefix24(run) + "/24"
 			prefix.Cidr = cidr
 

--- a/memory_test.go
+++ b/memory_test.go
@@ -1,6 +1,7 @@
 package ipam
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,4 +21,47 @@ func Test_UpdatePrefix(t *testing.T) {
 	require.NotNil(t, err)
 	require.Nil(t, p)
 	require.Equal(t, "prefix not found:1.2.3.4/24", err.Error())
+}
+
+// ensure that locks on memory storage work
+func Test_UpdatePrefix_Concurrent(t *testing.T) {
+	m := NewMemory()
+
+	for i := 0; i < 50000; i++ {
+
+		go func(run int) {
+			prefix := &Prefix{}
+			cidr := calcPrefix24(run) + "/24"
+			prefix.Cidr = cidr
+
+			p, err := m.CreatePrefix(prefix)
+			require.Nil(t, err)
+			require.NotNil(t, p)
+
+			p, err = m.ReadPrefix(cidr)
+			require.Nil(t, err)
+			require.NotNil(t, p)
+
+			p, err = m.UpdatePrefix(p)
+			require.Nil(t, err)
+			require.NotNil(t, p)
+
+			p, err = m.ReadPrefix(cidr)
+			require.Nil(t, err)
+			require.NotNil(t, p)
+
+			p, err = m.DeletePrefix(p)
+			require.Nil(t, err)
+			require.NotNil(t, p)
+		}(i)
+	}
+}
+
+// calcs distinct /24 prefix for given test run
+func calcPrefix24(run int) string {
+	i3 := run % 256
+	i2 := (run / 256) % 256
+	i1 := (run / 65536) % 256
+
+	return fmt.Sprintf("%d.%d.%d.0", i1, i2, i3)
 }

--- a/prefix.go
+++ b/prefix.go
@@ -20,6 +20,25 @@ type Prefix struct {
 	version                int64           // version is used for optimistic locking
 }
 
+func (p Prefix) DeepCopy() *Prefix {
+	return &Prefix{
+		Cidr:                   p.Cidr,
+		ParentCidr:             p.ParentCidr,
+		availableChildPrefixes: copyMap(p.availableChildPrefixes),
+		childPrefixLength:      p.childPrefixLength,
+		ips:                    copyMap(p.ips),
+		version:                p.version,
+	}
+}
+
+func copyMap(m map[string]bool) map[string]bool {
+	cm := make(map[string]bool, len(m))
+	for k, v := range m {
+		cm[k] = v
+	}
+	return cm
+}
+
 // Usage of ips and child Prefixes of a Prefix
 type Usage struct {
 	AvailableIPs      uint64

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -605,6 +605,12 @@ func TestGetHostAddresses(t *testing.T) {
 		require.NotNil(t, ips)
 		require.Equal(t, 254, len(ips))
 
+		ip, err := ipam.AcquireIP(cidr)
+		require.Error(t, err)
+		require.IsType(t, NoIPAvailableError{}, err)
+		require.Equal(t, "no more ips in prefix: 4.1.0.0/24 left, length of prefix.ips: 256", err.Error())
+		require.Nil(t, ip)
+
 		cidr = "3.1.0.0/26"
 		ips, err = ipam.GetHostAddresses(cidr)
 		if err != nil {
@@ -612,6 +618,12 @@ func TestGetHostAddresses(t *testing.T) {
 		}
 		require.NotNil(t, ips)
 		require.Equal(t, 62, len(ips))
+
+		ip, err = ipam.AcquireIP(cidr)
+		require.Error(t, err)
+		require.IsType(t, NoIPAvailableError{}, err)
+		require.Equal(t, "no more ips in prefix: 3.1.0.0/26 left, length of prefix.ips: 64", err.Error())
+		require.Nil(t, ip)
 	})
 }
 

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -629,6 +629,29 @@ func TestGetHostAddresses(t *testing.T) {
 	})
 }
 
+func TestPrefixDeepCopy(t *testing.T) {
+
+	p1 := &Prefix{
+		Cidr:                   "4.1.1.0/24",
+		ParentCidr:             "4.1.0.0/16",
+		availableChildPrefixes: map[string]bool{},
+		childPrefixLength:      256,
+		ips:                    map[string]bool{},
+		version:                2,
+	}
+
+	p1.availableChildPrefixes["4.1.2.0/24"] = true
+	p1.ips["4.1.1.1"] = true
+	p1.ips["4.1.1.2"] = true
+
+	p2 := p1.DeepCopy()
+
+	require.False(t, p1 == p2)
+	require.Equal(t, p1, p2)
+	require.False(t, &(p1.availableChildPrefixes) == &(p2.availableChildPrefixes))
+	require.False(t, &(p1.ips) == &(p2.ips))
+}
+
 func NewPostgres() (*sql, error) {
 	return NewPostgresStorage("localhost", "5433", "postgres", "password", "postgres", "disable")
 }

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -62,11 +62,13 @@ func TestIpamer_AcquireIP(t *testing.T) {
 			for _, ipString := range tt.fields.existingips {
 				p.ips[ipString] = true
 			}
-			p, err = ipam.storage.UpdatePrefix(p)
+
+			var updatedPrefix Prefix
+			updatedPrefix, err = ipam.storage.UpdatePrefix(*p)
 			if err != nil {
 				t.Errorf("Could not update prefix: %v", err)
 			}
-			got, _ := ipam.AcquireIP(p.Cidr)
+			got, _ := ipam.AcquireIP(updatedPrefix.Cidr)
 			if tt.want == nil || got == nil {
 				if !reflect.DeepEqual(got, tt.want) {
 					t.Errorf("Ipamer.AcquireIP() = %v, want %v", got, tt.want)

--- a/sql_test.go
+++ b/sql_test.go
@@ -24,7 +24,7 @@ func Test_sql_prefixExists(t *testing.T) {
 	require.NotNil(t, db)
 
 	// Existing Prefix
-	prefix := &Prefix{Cidr: "10.0.0.0/16"}
+	prefix := Prefix{Cidr: "10.0.0.0/16"}
 	p, err := db.CreatePrefix(prefix)
 	require.Nil(t, err)
 	require.NotNil(t, p)
@@ -34,7 +34,7 @@ func Test_sql_prefixExists(t *testing.T) {
 	require.Equal(t, got.Cidr, prefix.Cidr)
 
 	// NonExisting Prefix
-	notExistingPrefix := &Prefix{Cidr: "10.0.0.0/8"}
+	notExistingPrefix := Prefix{Cidr: "10.0.0.0/8"}
 	got, exists = db.prefixExists(notExistingPrefix)
 	require.False(t, exists)
 	require.Nil(t, got)
@@ -56,7 +56,7 @@ func Test_sql_CreatePrefix(t *testing.T) {
 	require.NotNil(t, db)
 
 	// Existing Prefix
-	prefix := &Prefix{Cidr: "11.0.0.0/16"}
+	prefix := Prefix{Cidr: "11.0.0.0/16"}
 	got, exists := db.prefixExists(prefix)
 	require.False(t, exists)
 	require.Nil(t, got)
@@ -92,9 +92,9 @@ func Test_sql_ReadPrefix(t *testing.T) {
 	p, err := db.ReadPrefix("12.0.0.0/8")
 	require.NotNil(t, err)
 	require.Equal(t, "unable to read prefix:sql: no rows in result set", err.Error())
-	require.Nil(t, p)
+	require.Empty(t, p)
 
-	prefix := &Prefix{Cidr: "12.0.0.0/16"}
+	prefix := Prefix{Cidr: "12.0.0.0/16"}
 	p, err = db.CreatePrefix(prefix)
 	require.Nil(t, err)
 	require.NotNil(t, p)
@@ -120,7 +120,7 @@ func Test_sql_ReadAllPrefix(t *testing.T) {
 	require.Equal(t, 0, len(ps))
 
 	// One Prefix
-	prefix := &Prefix{Cidr: "12.0.0.0/16"}
+	prefix := Prefix{Cidr: "12.0.0.0/16"}
 	p, err := db.CreatePrefix(prefix)
 	require.Nil(t, err)
 	require.NotNil(t, p)
@@ -147,7 +147,7 @@ func Test_sql_UpdatePrefix(t *testing.T) {
 	require.NotNil(t, db)
 
 	// Prefix
-	prefix := &Prefix{Cidr: "13.0.0.0/16", ParentCidr: "13.0.0.0/8"}
+	prefix := Prefix{Cidr: "13.0.0.0/16", ParentCidr: "13.0.0.0/8"}
 	p, err := db.CreatePrefix(prefix)
 	require.Nil(t, err)
 	require.NotNil(t, p)

--- a/sql_test.go
+++ b/sql_test.go
@@ -213,7 +213,7 @@ func acquire(t *testing.T, cidr string, prefixes chan string) {
 	for cp == nil {
 		cp, err = ipamer.AcquireChildPrefix(cidr, 26)
 		if err != nil {
-			t.Error("error AcquireChildPrefix")
+			t.Error(err)
 		}
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/storage.go
+++ b/storage.go
@@ -2,11 +2,11 @@ package ipam
 
 // Storage is a interface to store ipam objects.
 type Storage interface {
-	CreatePrefix(prefix *Prefix) (*Prefix, error)
-	ReadPrefix(prefix string) (*Prefix, error)
-	ReadAllPrefixes() ([]*Prefix, error)
-	UpdatePrefix(prefix *Prefix) (*Prefix, error)
-	DeletePrefix(prefix *Prefix) (*Prefix, error)
+	CreatePrefix(prefix Prefix) (Prefix, error)
+	ReadPrefix(prefix string) (Prefix, error)
+	ReadAllPrefixes() ([]Prefix, error)
+	UpdatePrefix(prefix Prefix) (Prefix, error)
+	DeletePrefix(prefix Prefix) (Prefix, error)
 }
 
 // OptimisticLockError indicates that the operation could not be executed because the dataset to update has changed in the meantime.


### PR DESCRIPTION
removed mutex, replaced by optimistic lock
added some doc
added cleaner business-error signaling in acquireIP
Please note: changed semantics on GetHostAddresses - now unexpected errors (other than "no free IP") are propagated, i.e. you do not get partial results if another error occurs but you clearly see that something failed